### PR TITLE
Remove ability to generate static methods from template 'keys'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+**This release contains breaking changes.**
+
+### Fixed
+
+### Added
+
+### Changed
+
+* **BREAKING**: Removed the possibility to add static methods to the classes
+  generated with the template `keys`. As replacement a String constant holding
+  the properties file name is created (`PROPERTIES_FILE_NAME`). For I18N a
+  constant holding the bundle name can be created (`BUNDLE_NAME`). This behavior
+  and the name of the constants is configurable.
+
 ## [0.3.0] - 2023-01-29
 
 ### Fixed
@@ -50,6 +66,7 @@ Initial implementation.
 
 
 
+[UNRELEASED]: https://github.com/rakus/properties-constants-maven-plugin/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/rakus/properties-constants-maven-plugin/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/rakus/properties-constants-maven-plugin/compare/v0.1.0...v0.2.0
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ package de.r3s6.maven.example;
 public final class Messages {
 
     /**
+     * Properties file used to generate this class: "messages.properties".
+     * <p>
+     * If this name should be used to load the properties via classpath,
+     * a leading slash ('/') might be needed.
+     */
+    public final static String PROPERTIES_FILE_NAME = "messages.properties";
+
+    /**
      * Key of welcome.user=Hello user
      */
     public final static String WELCOME_USER = "welcome.user";

--- a/src/it/empty-key/pom.xml
+++ b/src/it/empty-key/pom.xml
@@ -74,10 +74,6 @@
                             <includes>
                                 <include>*.properties</include>
                             </includes>
-                            <templateOptions>
-                                <genGetPropertiesFilename>true</genGetPropertiesFilename>
-                                <genLoadProperties>true</genLoadProperties>
-                            </templateOptions>
                         </configuration>
                     </execution>
                     <execution>
@@ -93,8 +89,6 @@
                             <excludes>
                                 <exclude>messages/*_??.properties</exclude>
                             </excludes>
-                            <genGetBundleName>true</genGetBundleName>
-                            <genBundleLoader>true</genBundleLoader>
                         </configuration>
                     </execution>
                     <execution>
@@ -107,8 +101,6 @@
                             <includes>
                                 <include>*.xml</include>
                             </includes>
-                            <genGetPropertiesFilename>true</genGetPropertiesFilename>
-                            <genPropertiesLoader>true</genPropertiesLoader>
                         </configuration>
                     </execution>
                     <execution>
@@ -122,8 +114,6 @@
                                 <include>subdir/*.properties</include>
                             </includes>
                             <flattenPackage>true</flattenPackage>
-                            <genGetPropertiesFilename>true</genGetPropertiesFilename>
-                            <genPropertiesLoader>true</genPropertiesLoader>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/test-prj/pom.xml
+++ b/src/it/test-prj/pom.xml
@@ -74,10 +74,6 @@
                             <includes>
                                 <include>*.properties</include>
                             </includes>
-                            <templateOptions>
-                                <genGetPropertiesFilename>true</genGetPropertiesFilename>
-                                <genLoadProperties>true</genLoadProperties>
-                            </templateOptions>
                         </configuration>
                     </execution>
                     <execution>
@@ -108,8 +104,8 @@
                                 <exclude>messages/*_??.properties</exclude>
                             </excludes>
                             <templateOptions>
-                                <genGetBundleName>true</genGetBundleName>
-                                <genLoadBundle>true</genLoadBundle>
+                                <genPropertiesFilenameConstant>true</genPropertiesFilenameConstant>
+                                <genBundleNameConstant>true</genBundleNameConstant>>
                             </templateOptions>
                         </configuration>
                     </execution>
@@ -123,10 +119,6 @@
                             <includes>
                                 <include>*.xml</include>
                             </includes>
-                            <templateOptions>
-                                <genGetPropertiesFilename>true</genGetPropertiesFilename>
-                                <genLoadProperties>true</genLoadProperties>
-                            </templateOptions>
                         </configuration>
                     </execution>
                     <execution>
@@ -140,10 +132,6 @@
                                 <include>subdir/*.properties</include>
                             </includes>
                             <flattenPackage>true</flattenPackage>
-                            <templateOptions>
-                                <genGetPropertiesFilename>true</genGetPropertiesFilename>
-                                <genLoadProperties>true</genLoadProperties>
-                            </templateOptions>
                         </configuration>
                     </execution>
                     <execution>

--- a/src/it/test-prj/src/main/java/de/tester/main/Tester.java
+++ b/src/it/test-prj/src/main/java/de/tester/main/Tester.java
@@ -24,7 +24,7 @@ public class Tester {
 
     public static void main(final String[] args) throws IOException {
 
-        final ResourceBundle props = Messages.loadBundle();
+        final ResourceBundle props = ResourceBundle.getBundle(Messages.BUNDLE_NAME);;
 
         System.out.println(props.getString(Messages.WELCOME));
         System.out.println(props.getString(Messages._0SET));

--- a/src/it/test-prj/src/test/java/de/tester/constants/ClasspathPropLoader.java
+++ b/src/it/test-prj/src/test/java/de/tester/constants/ClasspathPropLoader.java
@@ -1,0 +1,34 @@
+package de.tester.constants;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public final class ClasspathPropLoader {
+
+    public static Properties loadProperties(final String filename) throws IOException {
+        final Properties properties = new Properties();
+        try (InputStream stream = ClasspathPropLoader.class.getResourceAsStream("/" + filename)) {
+            if (stream == null) {
+                throw new IOException("Resource not found: /" + filename);
+            }
+            properties.load(stream);
+        }
+        return properties;
+    }
+
+    public static Properties loadXmlProperties(final String filename) throws IOException {
+        final Properties properties = new Properties();
+        try (InputStream stream = ClasspathPropLoader.class.getResourceAsStream("/" + filename)) {
+            if (stream == null) {
+                throw new IOException("Resource not found: /" + filename);
+            }
+            properties.loadFromXML(stream);
+        }
+        return properties;
+    }
+
+    private ClasspathPropLoader() {
+        // nothing to instantiate
+    }
+}

--- a/src/it/test-prj/src/test/java/de/tester/constants/SubPropsTest.java
+++ b/src/it/test-prj/src/test/java/de/tester/constants/SubPropsTest.java
@@ -33,12 +33,12 @@ class SubPropsTest {
 
     @Test
     void testPropertiesFilenameName() {
-        assertEquals("subdir/sub-props.properties", SubProps.getPropertiesFilename());
+        assertEquals("subdir/sub-props.properties", SubProps.PROPERTIES_FILE_NAME);
     }
 
     @Test
     void testPropertyLoad() throws IOException {
-        final Properties props = SubProps.loadProperties();
+        final Properties props = ClasspathPropLoader.loadProperties(SubProps.PROPERTIES_FILE_NAME);
         assertEquals("First", props.getProperty(SubProps.ONE));
         assertEquals("Second", props.getProperty(SubProps.TWO));
         assertEquals("Third", props.getProperty(SubProps.THREE));

--- a/src/it/test-prj/src/test/java/de/tester/constants/TestCaseTest.java
+++ b/src/it/test-prj/src/test/java/de/tester/constants/TestCaseTest.java
@@ -36,12 +36,12 @@ class TestCaseTest {
 
     @Test
     void testPropertiesFilenameName() {
-        assertEquals("test-case.properties", TestCase.getPropertiesFilename());
+        assertEquals("test-case.properties", TestCase.PROPERTIES_FILE_NAME);
     }
 
     @Test
     void testPropertyLoad() throws IOException {
-        final Properties props = TestCase.loadProperties();
+        final Properties props = ClasspathPropLoader.loadProperties(TestCase.PROPERTIES_FILE_NAME);
         assertEquals("ÄÖÜäöüß", props.getProperty(TestCase.UMLAUTS));
         assertEquals("Key 1", props.getProperty(TestCase.KEY_1));
         assertEquals("Key 2", props.getProperty(TestCase.KEY_2));

--- a/src/it/test-prj/src/test/java/de/tester/constants/XmlPropsTest.java
+++ b/src/it/test-prj/src/test/java/de/tester/constants/XmlPropsTest.java
@@ -35,12 +35,12 @@ class XmlPropsTest {
 
     @Test
     void testPropertiesFilenameName() {
-        assertEquals("xml-props.xml", XmlProps.getPropertiesFilename());
+        assertEquals("xml-props.xml", XmlProps.PROPERTIES_FILE_NAME);
     }
 
     @Test
     void testPropertyLoad() throws IOException {
-        final Properties props = XmlProps.loadProperties();
+        final Properties props = ClasspathPropLoader.loadXmlProperties(XmlProps.PROPERTIES_FILE_NAME);
         assertEquals("test0001 value", props.getProperty(XmlProps.TEST0001));
         assertEquals("test0002 value", props.getProperty(XmlProps.TEST0002));
         assertEquals("test0003 value", props.getProperty(XmlProps.TEST0003));

--- a/src/it/test-prj/src/test/java/de/tester/constants/messages/MessagesTest.java
+++ b/src/it/test-prj/src/test/java/de/tester/constants/messages/MessagesTest.java
@@ -34,17 +34,17 @@ class MessagesTest {
 
     @Test
     void testPropertiesFilenameName() {
-        assertEquals("messages/messages", Messages.getBundleName());
+        assertEquals("messages/messages", Messages.BUNDLE_NAME);
     }
 
     @Test
     void testPropertyLoad() throws IOException {
-        final ResourceBundle bdl = Messages.loadBundle(Locale.CHINESE);
+        final ResourceBundle bdl = ResourceBundle.getBundle(Messages.BUNDLE_NAME, Locale.CHINESE);
         assertEquals("Welcome to this test", bdl.getString(Messages.WELCOME));
         assertEquals("All zero", bdl.getString(Messages._0SET));
         assertEquals("Thanks for testing", bdl.getString(Messages.GOODBY));
 
-        final ResourceBundle bdlDe = Messages.loadBundle(Locale.GERMAN);
+        final ResourceBundle bdlDe = ResourceBundle.getBundle(Messages.BUNDLE_NAME, Locale.GERMAN);
         assertEquals("Willkommen zu diesem Test", bdlDe.getString(Messages.WELCOME));
         assertEquals("Alles Null", bdlDe.getString(Messages._0SET));
         assertEquals("Danke, dass Sie getestet haben", bdlDe.getString(Messages.GOODBY));

--- a/src/main/java/de/r3s6/maven/constcreator/GenerateMojo.java
+++ b/src/main/java/de/r3s6/maven/constcreator/GenerateMojo.java
@@ -150,15 +150,14 @@ public class GenerateMojo extends AbstractMojo {
      * <p>
      * The template <code>keys</code> supports the following options:
      * <dl>
-     * <dt>genGetPropertiesFilename</dt>
-     * <dd>generate the method <code>getPropertiesFilename()</code></dd>
-     * <dt>genLoadProperties</dt>
-     * <dd>generate the method <code>loadProperties()</code></dd>
-     * <dt>genGetBundleName</dt>
-     * <dd>generate the method <code>getBundleName()</code></dd>
-     * <dt>genLoadBundle</dt>
-     * <dd>generate the method <code>loadBundle()</code> and
-     * <code>loadBundle(Locale)</code></dd>
+     * <dt>genPropertiesFilenameConstant</dt>
+     * <dd>generate the constant <code>PROPERTIES_FILE_NAME()</code></dd>
+     * <dt>propertiesFilenameConstant</dt>
+     * <dd>changes the name of the properties file name constant</dd>
+     * <dt>genBundleNameConstant</dt>
+     * <dd>generate the constant <code>BUNDLE_NAME</code></dd>
+     * <dt>bundleNameConstant</dt>
+     * <dd>changes the name of the bundle name constant</dd>
      * </dl>
      */
     @Parameter

--- a/src/main/resources/plugin-default-templates/keys-template.ftl
+++ b/src/main/resources/plugin-default-templates/keys-template.ftl
@@ -14,22 +14,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<#assign genLoadBundle            = ((options.genLoadBundle!"false") == "true")>
-<#assign genLoadProperties        = ((options.genLoadProperties!"false") == "true")>
-<#assign genGetPropertiesFilename = ((options.genGetPropertiesFilename!"false") == "true")>
-<#assign genGetBundleName         = ((options.genGetBundleName!"false") == "true")>
+<#assign genPropertiesFilenameConstant = ((options.genPropertiesFilenameConstant!"true") == "true")>
+<#assign propertiesFilenameConstant    = options.propertiesFilenameConstant!"PROPERTIES_FILE_NAME">
+<#assign genBundleNameConstant         = ((options.genBundleNameConstant!"false") == "true")>
+<#assign bundleNameConstant            = options.bundleNameConstant!"BUNDLE_NAME">
 package ${pkgName};
-<#if genLoadBundle>
-
-import java.util.Locale;
-import java.util.ResourceBundle;
-</#if>
-<#if genLoadProperties>
-
-import java.util.Properties;
-import java.io.IOException;
-import java.io.InputStream;
-</#if>
 
 /**
  * Constants for ${propertiesFileName}
@@ -39,6 +28,23 @@ import java.io.InputStream;
  * @author properties-constants-maven-plugin
  */
 public final class ${simpleClassName} {
+<#if genPropertiesFilenameConstant>
+
+    /**
+     * Properties file used to generate this class: "${propertiesFileName}".
+     * <p>
+     * If this name should be used to load the properties via classpath,
+     * a leading slash ('/') might be needed.
+     */
+    public final static String ${propertiesFilenameConstant} = "${propertiesFileName}";
+</#if>
+<#if genBundleNameConstant>
+
+    /**
+     * ResourceBundle used to generate this class: "${bundleName}"
+     */
+    public final static String ${bundleNameConstant} = "${bundleName}";
+</#if>
 <#list entries as entry>
 
     /**
@@ -51,73 +57,5 @@ public final class ${simpleClassName} {
     private ${simpleClassName}() {
         // nothing to instantiate
     }
-<#if genGetPropertiesFilename>
-
-    /**
-     * Returns the filename of the properties file used to generate
-     * this class.
-     *
-     * @return always "${propertiesFileName}"
-     */
-    public static String getPropertiesFilename() {
-        return "${propertiesFileName}";
-    }
-</#if>
-<#if genLoadProperties>
-
-    /**
-     * Loads the properties file "${propertiesFileName}" from the classpath.
-     * @return the loaded properties
-     * @throws IOException if properties file not found or on load problems
-     */
-    public static Properties loadProperties() throws IOException {
-        final Properties properties = new Properties();
-        try (final InputStream stream = ${simpleClassName}.class.getResourceAsStream("/${propertiesFileName}")) {
-            if(stream == null) {
-                throw new IOException("Resource not found: ${propertiesFileName}");
-            }
-<#if isXmlProperties>
-            properties.loadFromXML(stream);
-<#else>
-            properties.load(stream);
-</#if>
-        }
-        return properties;
-    }
-</#if>
-<#if genGetBundleName>
-
-    /**
-     * Returns the bundle name - this is the properties file name
-     * used to generate this class excluding extension and locale part.
-     *
-     * @return always "${bundleName}"
-     */
-    public static String getBundleName() {
-        return "${bundleName}";
-    }
-</#if>
-<#if genLoadBundle>
-
-    /**
-     * Loads the resource bundle "${bundleName}" for the default locale.
-     * @return the loaded bundle
-     * @throws MissingResourceException if bundle couldn't be found
-     */
-    public static ResourceBundle loadBundle() {
-        return ResourceBundle.getBundle("${bundleName}");
-    }
-
-    /**
-     * Loads the resource bundle "${bundleName}" for the given locale.
-     * @param locale the locale to use
-     * @return the loaded bundle
-     * @throws MissingResourceException if bundle couldn't be found
-     * @throws NullPointerException if locale is null
-     */
-    public static ResourceBundle loadBundle(final Locale locale) {
-        return ResourceBundle.getBundle("${bundleName}", locale);
-    }
-</#if>
 
 }

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -27,26 +27,29 @@
         <faq id="is.this.a.good.idea">
             <question>Is creating constants for properties key a good idea at all?</question>
             <answer>
-                <p>Well, it depends.</p>
-                <p>This helps the developers to check at compile time whether the
-                properties key is valid or not (assuming he/she uses the constant with the right
+                <p>Yes, this helps the developers to check at compile time whether the
+                properties key is valid or not (assuming the constants are used with the right
                     properties file).</p>
-                <p>While this is useful, it might depend on the size of the properties file. If it
-                contains hundreds or even thousands of entries, I'm not sure whether it is a good
-                    idea to create a Java class containing that number of String constants.</p>
-                <p>So: Make you own judgment whether this plugin is a good idea for your use case
-                or your specific context.</p>
+                <p>A common concern is about big properties files, e.g. for I18N they might contain
+                hundreds or more entries. The classes for this kind of properties files will be big
+                (or even huge). But that doesn't matter, as the Java compiler embeds the constant
+                values into the classes using them. The constant class itself is not loaded at
+                    runtime.</p>
+                <p>So, if the constants class is huge, it is a compile-time problem, not a runtime one.</p>
             </answer>
         </faq>
         <faq id="size.limit">
-            <question>Is there a limit for the number of constants in a class?</question>
+            <question>How big can a properties file be to work with the plugin?</question>
             <answer>
-                <p>I don't know, but I wouldn't be surprised.</p>
-                <p>For testing a properties file with 20,000 entries was created with each key being
-                44 chars long and every value 106. The Java source generated from this file had
-                    100,080 lines and the compiled class file was about 2.2 MB.</p>
-                <p>This worked with Java 8, 11 and 17.</p>
-                <p>Anyway, creating a constants class of this size is most likely not a good idea.</p>
+                <p>If using the default templates "keys", the maximum number of entries
+                in a properties file is 21838. This would result in a Java class with
+                21839 String constants, as an additional constant for the properties file
+                    name is created.</p>
+                <p>This is the maximum number of String constants a class can have, assuming all
+                constant values are different and the class has only the default constructor and
+                    no other method.</p>
+                <p>To understand this odd number, you might want to read up on the "constant pool"
+                    of the Java class file.</p>
             </answer>
         </faq>
         <faq id="central.custom.template">
@@ -55,7 +58,7 @@
                 <p>Do it with a Maven dependency.</p>
                 <p>Create a jar that only contains your Freemarker template and deploy it to your
                     local Maven repository.</p>
-                <p>Then configure the plugin like this:</p>
+                <p>Then configure the plugin similar to this:</p>
                 <source><![CDATA[
 <plugin>
   <groupId>de.r3s6.maven</groupId>
@@ -81,10 +84,7 @@
                 Does the <code>properties-constants-maven-plugin</code> support XML properties?
             </question>
             <answer>
-                <p>Yes, if the configuration also includes <code>*.xml</code> files, those files
-                are read using <code>Properties.loadFromXml()</code>.</p>
-                <p>If a constant class is created from an XML file, the loader method
-                <code>loadProperties()</code> also uses <code>loadFromXml()</code>.</p>
+                <p>Yes, if the configuration also includes <code>*.xml</code> files.</p>
                 <p>To include XML files use the configuration option <code>&lt;includes&gt;</code>
                 like:
                 </p>
@@ -96,8 +96,6 @@
                 <p> Note that the content must comply to the simple
                 <a href="http://java.sun.com/dtd/properties.dtd">Properties DTD</a>.
                 </p>
-                <p>Loading XML-Files as <code>ResourceBundle</code> is not supported out of the box.
-                See <a href="#xml.resourcebundle">this question</a></p>
             </answer>
         </faq>
         <faq id="file.extensions">
@@ -106,31 +104,6 @@
                 <p>The plugin only cares whether the file has the extension <code>xml</code> or not.
                 Files with the extension <code>xml</code> (case insensitive) are read as XML.
                 All other extensions are handled like <code>*.properties</code>.</p>
-            </answer>
-        </faq>
-        <faq id="load.failed">
-            <question>Load of Properties or ResourceBundle failed at runtime. Why?</question>
-            <answer>
-            <p>The generated static methods <code>loadProperties()</code> and <code>loadBundle(...)</code> use the
-            class loader to load the properties file. Prerequisites are:</p>
-            <ol>
-            <li>the properties file are added to the created jar and are available on the classpath</li>
-            <li>the configuration options <code>&lt;resourceDir&gt;</code> and <code>&lt;includes&gt;</code> are
-                used correctly</li>
-            </ol>
-            <p>The second point needs some explanation. The path to the properties file in the
-            generated Java code is relative to the configuration option <code>&lt;resourceDir&gt;</code>.
-            If the properties files to translate are located in <code>src/main/resources/messages</code>,
-            the plugin needs following configuration:</p>
-        <source><![CDATA[
-<configuration>
-  <resourceDir>src/main/resources</resourceDir>   <!-- the default -->
-  <includes>
-    <include>messages/*.properties</include>
-  </includes>
-</configuration>]]></source>
-            <p>Then the path to the properties in the generated Java file is <code>messages/xyz.properties</code>
-            and loading works.</p>
             </answer>
         </faq>
 

--- a/src/site/markdown/code-templates.md
+++ b/src/site/markdown/code-templates.md
@@ -13,24 +13,60 @@ The template `keys` creates a Java class that contains String constants holding
 the property keys. This is useful to access the properties values at runtime.
 
 As this requires to load the properties as `Properties` or `ResourceBundle`,
-the template can be configured to create methods to load these. Examples for
-the created methods are shown in the [Introduction].
+the template provides a constant with the properties file name and if configured
+the resource bundle name.
 
-The following example enables ale possible options.
+### Options
 
+#### `genPropertiesFilenameConstant`
+Boolean (`true`/`false`), Default: `true`
+
+Adds the constant `PROPERTIES_FILE_NAME` to the generated class. This holds
+the name needed to load the properties file. The name of the constant can be
+changed with the option `propertiesFilenameConstant`.
+
+Typically `genPropertiesFilenameConstant` is set to `false` when
+`genBundleNameConstant` is `true`.
+
+#### `propertiesFilenameConstant`
+String, Default: `PROPERTIES_FILE_NAME`
+
+Name of the constant holding the properties file name. The value must be a
+valid Java variable name.
+
+#### `genBundleNameConstant`
+Boolean (`true`/`false`), Default: `false`
+
+Adds the constant `BUNDLE_NAME` to the generated class. This holds the bundle
+name; hence, the name of the properties file without extension and locale
+markers. The name of the constant can be changed with the option
+`bundleNameConstant`.
+
+Typically `genPropertiesFilenameConstant` is set to `false` when
+`genBundleNameConstant` is `true`.
+
+#### `bundleNameConstant`
+String, Default: `BUNDLE_NAME`
+
+Name of the constant holding the bundle name. The value must be a valid Java
+variable name.
+
+#### Example
+
+The following example shows the default configuration
 ```
 <templateOptions>
-    <genGetPropertiesFilename>true</genGetPropertiesFilename>
-    <genLoadProperties>true</genLoadProperties>
-    <genGetBundleName>true</genGetBundleName>
-    <genLoadBundle>true</genLoadBundle>
+    <genPropertiesFilenameConstant>true</genPropertiesFilenameConstant>
+    <propertiesFilenameConstant>PROPERTIES_FILE_NAME</propertiesFilenameConstant>
+    <genBundleNameConstant>false</genBundleNameConstant>
+    <bundleNameConstant>BUNDLE_NAME</bundleNameConstant>
 </templateOptions>
 ```
 
 ### Template `values`
 
 The template `values` creates a Java class that contains String constants holding
-the property values. Then the properties files itself are _not needed_ as runtime.
+the property values. Then the properties files itself are _not needed_ at runtime.
 
 This template does not support any additional options.
 
@@ -102,14 +138,14 @@ configured in the pom like:
 
 ```
 <templateOptions>
-    <genLoadProperties>true</genLoadProperties>
+    <addCopyright>true</addCopyright>
     <company>ACME</company>
 </templateOptions>
 ```
 
 This makes the following variables accessible in the template:
 
-* `${options.genLoadProperties}`
+* `${options.addCopyright}`
 * `${options.company}`
 
 Important: This are both of type `String`.
@@ -121,14 +157,13 @@ that they might be unset (aka `null`).  The simplest way is to define a boolean
 variable in the context of the template:
 
 ```
-<#assign genLoadProperties = ((options.genLoadProperties!"false") == "true")>
+<#assign addCopyright = ((options.addCopyright!"false") == "true")>
 ...
-<#if genLoadProperties>
+<#if addCopyright>
 ...
 </#if>
 ```
 
-[Introduction]: /index.html#
 [Freemarker]: https://freemarker.apache.org/
 [Freemarker documentation]: https://freemarker.apache.org/docs/index.html
 

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -16,9 +16,6 @@ properties. By configuration the class could be generated to contain constants
 holding the values from the properties file. In this case the properties file
 itself is not needed during runtime.
 
-If requested, the classes contain methods to load the properties file as
-`ResourceBundle` or `Properties`.
-
 In Eclipse the plugin goal `generate` is used as a build participant and runs on
 incremental and clean builds.
 
@@ -42,6 +39,11 @@ With the default template `keys` the following Java class will be generated.
  * @author properties-constants-maven-plugin
  */
 public final class Messages {
+
+    /**
+     * Properties file used to generate this class: "messages.properties".
+     */
+    public final static String PROPERTIES_FILE_NAME = "messages.properties";
 
     /**
      * Key of welcome=Welcome to Maven
@@ -85,88 +87,6 @@ public final class Messages {
     private Messages() {
         // nothing to instantiate
     }
-}
-```
-
-$H3 Additional Methods
-
-The default template `keys` supports template options to generate additional
-static methods in the generated class.
-
-Note that the template `values` does not support any template options.
-
-Option `genGetPropertiesFilename` adds a method to get the properties file name
-relative to the configured base directory:
-
-```java
-/**
- * Returns the filename of the properties file used to generate
- * this class.
- *
- * @return always "messages.properties"
- */
-public static String getPropertiesFilename() {
-    return "messages.properties";
-}
-```
-
-Option `genLoadProperties` adds a method to load the `Properties`:
-
-```java
-/**
- * Loads the properties file "messages.properties" from the classpath.
- * @return the loaded properties
- * @throws IOException if properties file not found or on load problems
- */
-public static Properties loadProperties() throws IOException {
-    final Properties properties = new Properties();
-    try (final InputStream stream = Messages.class.getResourceAsStream("/messages.properties")) {
-        if(stream == null) {
-            throw new IOException("Resource not found: messages.properties");
-        }
-        properties.load(stream);
-    }
-    return properties;
-}
-```
-
-Option `genGetBundleName` adds a method to get the bundle name. This is
-the properties file name excluding extension and possible locale marker.
-
-```java
-/**
- * Returns the bundle name - this is the properties file name
- * used to generate this class excluding extension and locale part.
- *
- * @return always "messages"
- */
-public static String getBundleName() {
-    return "messages";
-}
-```
-
-Option `genLoadBundle` adds methods to load the properties file as
-`ResourceBundle`.
-
-```java
-/**
- * Loads the resource bundle "messages" for the default locale.
- * @return the loaded bundle
- * @throws MissingResourceException if bundle couldn't be found
- */
-public static ResourceBundle loadBundle() {
-    return ResourceBundle.getBundle("messages");
-}
-
-/**
- * Loads the resource bundle "messages" for the given locale.
- * @param locale the locale to use
- * @return the loaded bundle
- * @throws MissingResourceException if bundle couldn't be found
- * @throws NullPointerException if locale is null
- */
-public static ResourceBundle loadBundle(final Locale locale) {
-    return ResourceBundle.getBundle("messages", locale);
 }
 ```
 

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -21,7 +21,7 @@ The following diagram shows the default layout used by the properties-constants-
 $H2 Simple properties
 
 Reads `*.properties` files from `src/main/resources` and generates Java classes
-in the package `de.r3s6.constants`. Support methods for Properties are generated.
+in the package `de.r3s6.constants`.
 
 The default template "keys" is used.
 
@@ -40,10 +40,6 @@ The default template "keys" is used.
                     </goals>
                     <configuration>
                         <basePackage>de.r3s6.constants</basePackage>
-                        <templateOptions>
-                            <genGetPropertiesFilename>true</genGetPropertiesFilename>
-                            <genLoadProperties>true</genLoadProperties>
-                        </templateOptions>
                     </configuration>
                 </execution>
             </executions>
@@ -81,8 +77,9 @@ To create constants that contains property values, use the template "values".
 $H2 I18N - ResourceBundle
 
 Reads ResourceBundle properties files from `src/main/resources/i18n`. It ignores
-files with a locale marker (like `messages_en.properties`). Support methods for
-ResourceBundles are generated.
+files with a locale marker (like `messages_en.properties`). Instead of the constant
+holding the properties file name, a constant holding the bundle name is added to
+the generated class.
 
 ```xml
 <build>
@@ -100,8 +97,8 @@ ResourceBundles are generated.
                     <exclude>i18n/*_??.properties</exclude>
                 </excludes>
                 <templateOptions>
-                    <genGetBundleName>true</genGetBundleName>
-                    <genLoadBundle>true</genLoadBundle>
+                    <genPropertiesFilenameConstant>false</genPropertiesFilenameConstant>
+                    <genBundleNameConstant>true</genBundleNameConstant>
                 </templateOptions>
             </configuration>
             <executions>


### PR DESCRIPTION
As the Java compiler embeds the constants into the class using them, the constants class itself is actually not loaded/needed at runtime.

By generating static methods, the constants class has to be loaded by the JVM when they are used. If the constants class contains a lot of constants, this is not desirable.